### PR TITLE
globals: WindowState module for position + visibility persistence

### DIFF
--- a/gearswap/gearswap.lua
+++ b/gearswap/gearswap.lua
@@ -37,37 +37,10 @@ gearListWindow:SetExtent(0, 0)
 --gearListWindow:AddAnchor("RIGHT", "UIParent", -100, -200)
 gearListWindow:EnableDrag(true)
 gearListWindow:Show(true)
-local function GetUIScaleFactor()
-	return UIParent:GetUIScale() or 1.0
-end
 
 local gearWidgets = {}
 
-local filePath = "GearWindowPos.txt"
-local function SaveWindowPosition(x, y)
-	local uiScale = GetUIScaleFactor()
-	x = math.floor(x / uiScale)
-	y = math.floor(y / uiScale)
-	local file = io.open(filePath, "w")
-	file:write(string.format("%d,%d", x, y))
-	file:close()
-end
-local function LoadSavedPosition()
-	local file = io.open(filePath, "r")
-	if not file then
-		return 0, 0
-	end
-	local line = file:read("*line")
-	file:close()
-	local x, y = line:match("(%d+),(%d+)")
-	if x and y then
-		return x, y
-	else
-		return 0, 0
-	end
-end
-local savedWindowX, savedWindowY = LoadSavedPosition()
-gearListWindow:AddAnchor("TOPLEFT", "UIParent", tonumber(savedWindowX), tonumber(savedWindowY))
+WindowState.TrackPosition(gearListWindow, "GearWindowPos.txt", 0, 0)
 
 local background = gearListWindow:CreateColorDrawable(0, 0, 0, 0.5, "background")
 background:AddAnchor("TOPLEFT", gearListWindow, 0, 0)
@@ -414,20 +387,4 @@ local RegistUIEvent = function(window, eventTable)
 	end
 end
 RegistUIEvent(chatEventListenerAggro, chatAggroEventListenerEvents)
---
---make draggable window
-function gearListWindow:OnDragStart()
-	self:StartMoving()
-	self.moving = true
-end
-gearListWindow:SetHandler("OnDragStart", gearListWindow.OnDragStart)
-function gearListWindow:OnDragStop()
-	self:StopMovingOrSizing()
-	self.moving = false
-	local offsetX, offsetY = self:GetOffset()
-	local uiScale = UIParent:GetUIScale() or 1.0
-	local normalizedX = offsetX * uiScale
-	local normalizedY = offsetY * uiScale
-	SaveWindowPosition(normalizedX, normalizedY)
-end
-gearListWindow:SetHandler("OnDragStop", gearListWindow.OnDragStop)
+-- Window position is persisted by WindowState.TrackPosition (see top of file).

--- a/gearswap/toc.g
+++ b/gearswap/toc.g
@@ -5,4 +5,5 @@
 ../globals/button.lua
 ../globals/classmappings.lua
 ../globals/barmaker.lua
+../globals/windowstate.lua
 gearswap.lua

--- a/globals/windowstate.lua
+++ b/globals/windowstate.lua
@@ -1,0 +1,88 @@
+-------------- Original Author: Strawberry --------------
+----------------- Discord: exec_noir --------------------
+-- Window state persistence: where a window sits on screen, and whether it is
+-- shown or hidden. This absorbs the per-addon file IO, drag wiring, and
+-- UI-scale handling that was previously copy-pasted into each addon.
+--
+-- Position is stored as a "x,y" pair in a per-addon text file. Visibility is
+-- stored against an addon-chosen key via ADDON:SaveData.
+
+WindowState = WindowState or {}
+
+-- Reads a saved "x,y" TOPLEFT offset from filePath. Returns defaultX, defaultY
+-- (each defaulting to 0) when the file is missing, empty, or malformed.
+function WindowState.LoadPosition(filePath, defaultX, defaultY)
+	defaultX = defaultX or 0
+	defaultY = defaultY or 0
+
+	local file = io.open(filePath, "r")
+	if not file then
+		return defaultX, defaultY
+	end
+
+	local line = file:read("*line")
+	file:close()
+
+	if line == nil then
+		return defaultX, defaultY
+	end
+
+	local x, y = line:match("(%-?%d+),(%-?%d+)")
+	if x and y then
+		return tonumber(x), tonumber(y)
+	end
+
+	return defaultX, defaultY
+end
+
+-- Writes a TOPLEFT offset to filePath as "x,y". Returns true on success.
+function WindowState.SavePosition(filePath, x, y)
+	local file = io.open(filePath, "w")
+	if not file then
+		return false
+	end
+
+	file:write(string.format("%d,%d", math.floor(x or 0), math.floor(y or 0)))
+	file:close()
+	return true
+end
+
+-- Anchors window at its saved position (or the supplied default) and persists
+-- the position to filePath whenever the user finishes dragging the window.
+-- The window must already have drag enabled (window:EnableDrag(true)).
+function WindowState.TrackPosition(window, filePath, defaultX, defaultY)
+	local x, y = WindowState.LoadPosition(filePath, defaultX, defaultY)
+	window:AddAnchor("TOPLEFT", "UIParent", x, y)
+
+	window:SetHandler("OnDragStart", function(self)
+		self:StartMoving()
+		self.moving = true
+	end)
+
+	window:SetHandler("OnDragStop", function(self)
+		self:StopMovingOrSizing()
+		self.moving = false
+		local offsetX, offsetY = self:GetOffset()
+		WindowState.SavePosition(filePath, offsetX or 0, offsetY or 0)
+	end)
+end
+
+-- Returns the saved shown/hidden state for key, or default (which itself
+-- defaults to true) when nothing has been saved yet.
+function WindowState.LoadVisibility(key, default)
+	local saved = ADDON:LoadData(key)
+	if saved ~= nil and saved.shown ~= nil then
+		return saved.shown == true
+	end
+
+	if default == nil then
+		return true
+	end
+	return default == true
+end
+
+-- Persists the shown/hidden state for key.
+function WindowState.SaveVisibility(key, shown)
+	ADDON:ClearData(key)
+	ADDON:SaveData(key, { shown = shown == true })
+end

--- a/timeuntil/timeuntil.lua
+++ b/timeuntil/timeuntil.lua
@@ -29,19 +29,6 @@ local countFilePath = "TimeUntilWindowCount.txt"
 local filterFilePath = "TimeUntilEventFilters.txt"
 local VISIBILITY_SAVE_KEY = "timeuntil_visibility"
 
-local function LoadVisibility()
-	local saved = ADDON:LoadData(VISIBILITY_SAVE_KEY)
-	if saved ~= nil and saved.shown ~= nil then
-		return saved.shown == true
-	end
-	return true
-end
-
-local function SaveVisibility(shown)
-	ADDON:ClearData(VISIBILITY_SAVE_KEY)
-	ADDON:SaveData(VISIBILITY_SAVE_KEY, { shown = shown == true })
-end
-
 local function SaveTimerCount(count)
 	local file = io.open(countFilePath, "w")
 	file:write(tostring(count))
@@ -94,8 +81,7 @@ end
 ---
 
 local timerAnchor = CreateEmptyWindow("timerAnchor", "UIParent")
-timerAnchor:Show(LoadVisibility())
-timerAnchor:AddAnchor("TOPLEFT", "UIParent", 100, 100)
+timerAnchor:Show(WindowState.LoadVisibility(VISIBILITY_SAVE_KEY))
 timerAnchor:SetExtent(150, 50)
 timerAnchor:EnableDrag(true)
 local background = timerAnchor:CreateColorDrawable(0, 0, 0, 0.5, "background")
@@ -170,49 +156,7 @@ end
 lessEntries:SetHandler("OnClick", lessEntries.OnClick)
 
 ----- save draggable window ----------
-local filePath = "TimeUntilWindowPos.txt"
-local function GetUIScaleFactor()
-	return UIParent:GetUIScale() or 1.0
-end
-local function SaveWindowPosition(x, y)
-	local uiScale = GetUIScaleFactor()
-	x = math.floor(x / uiScale)
-	y = math.floor(y / uiScale)
-	local file = io.open(filePath, "w")
-	file:write(string.format("%d,%d", x, y))
-	file:close()
-end
-local function LoadSavedPosition()
-	local file = io.open(filePath, "r")
-	if not file then
-		return 0, 0
-	end
-	local line = file:read("*line")
-	file:close()
-	local x, y = line:match("(%d+),(%d+)")
-	if x and y then
-		return x, y
-	else
-		return 0, 0
-	end
-end
-function timerAnchor:OnDragStart()
-	self:StartMoving()
-	self.moving = true
-end
-timerAnchor:SetHandler("OnDragStart", timerAnchor.OnDragStart)
-function timerAnchor:OnDragStop()
-	self:StopMovingOrSizing()
-	self.moving = false
-	local offsetX, offsetY = self:GetOffset()
-	local uiScale = UIParent:GetUIScale() or 1.0
-	local normalizedX = offsetX * uiScale
-	local normalizedY = offsetY * uiScale
-	SaveWindowPosition(normalizedX, normalizedY)
-end
-timerAnchor:SetHandler("OnDragStop", timerAnchor.OnDragStop)
-local savedWindowX, savedWindowY = LoadSavedPosition()
-timerAnchor:AddAnchor("TOPLEFT", "UIParent", tonumber(savedWindowX), tonumber(savedWindowY))
+WindowState.TrackPosition(timerAnchor, "TimeUntilWindowPos.txt", 0, 0)
 
 local whaleConflict = false
 local aegConflict = true
@@ -528,7 +472,7 @@ local timeUntilMenuButton = CreateSimpleButton("timeuntil", 700, -490)
 timeUntilMenuButton:SetHandler("OnClick", function()
 	local show = not timerAnchor:IsVisible()
 	timerAnchor:Show(show)
-	SaveVisibility(show)
+	WindowState.SaveVisibility(VISIBILITY_SAVE_KEY, show)
 
 	if not show and filterWindow ~= nil then
 		filterWindow:Show(false)

--- a/timeuntil/toc.g
+++ b/timeuntil/toc.g
@@ -3,6 +3,7 @@
 ../globals/button.lua
 ../globals/windowcommon.lua
 ../globals/window.lua
+../globals/windowstate.lua
 EventNames.lua
 RuTimers.lua
 NATimers.lua


### PR DESCRIPTION
## What

Adds `globals/windowstate.lua`, a single module that owns **where a window sits on screen** and **whether it is shown or hidden**, and migrates `gearswap` and `timeuntil` onto it.

## Why

`SaveWindowPosition` / `LoadSavedPosition` / `GetUIScaleFactor` were byte-for-byte identical copies in `gearswap/gearswap.lua` and `timeuntil/timeuntil.lua`, and `dpsmeter` inlines a third variant. The shown/hidden persistence (`ADDON:SaveData`) was likewise copied between `dpsmeter` and `timeuntil`.

Two latent bugs were carried in every copy:

1. **No-op UI-scale dance** - on drag stop the offset was multiplied by UI scale, then `SaveWindowPosition` divided it straight back, and load never scaled at all. The scale handling did nothing but looked load-bearing, so any "fix" to one half would silently break position persistence.
2. **Negative offsets reset to 0,0** - the `(%d+),(%d+)` pattern rejected negative coordinates, so a window dragged to a negative offset jumped back to the corner on reload. Now matched with `%-?%d+`.

Both are fixed once, in one place.

## Interface

```lua
WindowState.TrackPosition(window, filePath, defaultX, defaultY)  -- anchor at saved spot + persist on drag stop
WindowState.LoadVisibility(key, default)                          -- saved shown/hidden, or default
WindowState.SaveVisibility(key, shown)
WindowState.LoadPosition(filePath, defaultX, defaultY)            -- lower-level, returns x, y
WindowState.SavePosition(filePath, x, y)
```

Callers drop from ~25 lines of file IO and drag wiring to a single `TrackPosition` call.

## Compatibility

Saved-file paths and formats are unchanged (`GearWindowPos.txt`, `TimeUntilWindowPos.txt`, the `*_visibility` SaveData keys), so existing saved positions and visibility carry over with no migration. Net diff is +95 / -104.

`dpsmeter`'s inlined variant is intentionally left for a follow-up to keep this PR's blast radius small.

## Testing

- `luacheck` clean on `globals/windowstate.lua`; no new warnings introduced in the migrated files.
- The repo has no headless harness, so the in-game position/visibility round-trip has **not** been verified live. The migration preserves the exact net behaviour of the previous code (the removed scale dance was a no-op), and saved-file formats are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)