### PR TITLE
ci: add busted unit-test pipeline

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,7 @@
+return {
+	default = {
+		verbose = true,
+		ROOT = { "spec" },
+		pattern = "_spec%.lua$",
+	},
+}

--- a/.github/workflows/lua-test.yml
+++ b/.github/workflows/lua-test.yml
@@ -1,0 +1,37 @@
+name: Lua Tests
+
+on:
+  push:
+    paths:
+      - "**/*.lua"
+      - "spec/**"
+      - ".busted"
+      - ".github/workflows/lua-test.yml"
+  pull_request:
+    paths:
+      - "**/*.lua"
+      - "spec/**"
+      - ".busted"
+      - ".github/workflows/lua-test.yml"
+
+jobs:
+  busted:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v11
+        with:
+          luaVersion: "5.1"
+
+      - name: Setup LuaRocks
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Install busted
+        run: luarocks install busted
+
+      - name: Run tests
+        run: busted

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@
 .luacheckrc
 README.md
 
+# CI / tooling
+!.busted
+!.github/**
+!spec/**
+
 # Addons
 !autoscanner/**
 !autoraidkick/**

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ powershell -ExecutionPolicy Bypass -File .\scripts\install-hooks.ps1
 
 This enables `.githooks/pre-commit`, which lints staged `.lua` files before each commit.
 
+## Tests
+
+Unit tests cover the game-independent modules in `globals/` (currently `windowstate.lua`) and run on every push and pull request via the `Lua Tests` workflow.
+
+Tests use [busted](https://lunarmodules.github.io/busted/). Install and run locally:
+
+```powershell
+luarocks install busted
+busted
+```
+
+Specs live in `spec/` and end in `_spec.lua`. Modules that talk to the live ArcheRage UI API (`UIParent`, `X2*`, widgets) cannot be tested headless; keep testable logic free of those globals so it can be covered here.
+
 # Current Addons:
 
 ## Autorole  

--- a/globals/windowstate.lua
+++ b/globals/windowstate.lua
@@ -1,0 +1,88 @@
+-------------- Original Author: Strawberry --------------
+----------------- Discord: exec_noir --------------------
+-- Window state persistence: where a window sits on screen, and whether it is
+-- shown or hidden. This absorbs the per-addon file IO, drag wiring, and
+-- UI-scale handling that was previously copy-pasted into each addon.
+--
+-- Position is stored as a "x,y" pair in a per-addon text file. Visibility is
+-- stored against an addon-chosen key via ADDON:SaveData.
+
+WindowState = WindowState or {}
+
+-- Reads a saved "x,y" TOPLEFT offset from filePath. Returns defaultX, defaultY
+-- (each defaulting to 0) when the file is missing, empty, or malformed.
+function WindowState.LoadPosition(filePath, defaultX, defaultY)
+	defaultX = defaultX or 0
+	defaultY = defaultY or 0
+
+	local file = io.open(filePath, "r")
+	if not file then
+		return defaultX, defaultY
+	end
+
+	local line = file:read("*line")
+	file:close()
+
+	if line == nil then
+		return defaultX, defaultY
+	end
+
+	local x, y = line:match("(%-?%d+),(%-?%d+)")
+	if x and y then
+		return tonumber(x), tonumber(y)
+	end
+
+	return defaultX, defaultY
+end
+
+-- Writes a TOPLEFT offset to filePath as "x,y". Returns true on success.
+function WindowState.SavePosition(filePath, x, y)
+	local file = io.open(filePath, "w")
+	if not file then
+		return false
+	end
+
+	file:write(string.format("%d,%d", math.floor(x or 0), math.floor(y or 0)))
+	file:close()
+	return true
+end
+
+-- Anchors window at its saved position (or the supplied default) and persists
+-- the position to filePath whenever the user finishes dragging the window.
+-- The window must already have drag enabled (window:EnableDrag(true)).
+function WindowState.TrackPosition(window, filePath, defaultX, defaultY)
+	local x, y = WindowState.LoadPosition(filePath, defaultX, defaultY)
+	window:AddAnchor("TOPLEFT", "UIParent", x, y)
+
+	window:SetHandler("OnDragStart", function(self)
+		self:StartMoving()
+		self.moving = true
+	end)
+
+	window:SetHandler("OnDragStop", function(self)
+		self:StopMovingOrSizing()
+		self.moving = false
+		local offsetX, offsetY = self:GetOffset()
+		WindowState.SavePosition(filePath, offsetX or 0, offsetY or 0)
+	end)
+end
+
+-- Returns the saved shown/hidden state for key, or default (which itself
+-- defaults to true) when nothing has been saved yet.
+function WindowState.LoadVisibility(key, default)
+	local saved = ADDON:LoadData(key)
+	if saved ~= nil and saved.shown ~= nil then
+		return saved.shown == true
+	end
+
+	if default == nil then
+		return true
+	end
+	return default == true
+end
+
+-- Persists the shown/hidden state for key.
+function WindowState.SaveVisibility(key, shown)
+	ADDON:ClearData(key)
+	ADDON:SaveData(key, { shown = shown == true })
+end

--- a/spec/windowstate_spec.lua
+++ b/spec/windowstate_spec.lua
@@ -1,0 +1,147 @@
+-- Tests for globals/windowstate.lua
+--
+-- WindowState is the first addon module whose interface is independent of the
+-- live ArcheRage UI API, so it is the first thing the project can test headless.
+-- LoadPosition/SavePosition use real temp files; the visibility helpers and
+-- TrackPosition are exercised against lightweight mocks of ADDON and a window.
+
+local function tmpPath()
+	local path = os.tmpname()
+	-- os.tmpname may create the file; start from a clean slate for each test.
+	os.remove(path)
+	return path
+end
+
+describe("WindowState", function()
+	setup(function()
+		dofile("globals/windowstate.lua")
+	end)
+
+	describe("LoadPosition", function()
+		it("returns the supplied defaults when the file is missing", function()
+			local x, y = WindowState.LoadPosition("/does/not/exist.txt", 12, 34)
+			assert.equals(12, x)
+			assert.equals(34, y)
+		end)
+
+		it("defaults to 0,0 when no defaults are supplied", function()
+			local x, y = WindowState.LoadPosition("/does/not/exist.txt")
+			assert.equals(0, x)
+			assert.equals(0, y)
+		end)
+
+		it("falls back to defaults on malformed contents", function()
+			local path = tmpPath()
+			local f = io.open(path, "w")
+			f:write("not a coordinate")
+			f:close()
+
+			local x, y = WindowState.LoadPosition(path, 7, 8)
+			assert.equals(7, x)
+			assert.equals(8, y)
+			os.remove(path)
+		end)
+	end)
+
+	describe("SavePosition / LoadPosition round-trip", function()
+		it("preserves a saved position", function()
+			local path = tmpPath()
+			assert.is_true(WindowState.SavePosition(path, 100, 250))
+
+			local x, y = WindowState.LoadPosition(path)
+			assert.equals(100, x)
+			assert.equals(250, y)
+			os.remove(path)
+		end)
+
+		it("restores negative offsets (regression: old %d+ pattern reset them to 0,0)", function()
+			local path = tmpPath()
+			WindowState.SavePosition(path, -40, -5)
+
+			local x, y = WindowState.LoadPosition(path)
+			assert.equals(-40, x)
+			assert.equals(-5, y)
+			os.remove(path)
+		end)
+
+		it("floors fractional offsets", function()
+			local path = tmpPath()
+			WindowState.SavePosition(path, 10.9, 20.1)
+
+			local x, y = WindowState.LoadPosition(path)
+			assert.equals(10, x)
+			assert.equals(20, y)
+			os.remove(path)
+		end)
+	end)
+
+	describe("visibility", function()
+		before_each(function()
+			local store = {}
+			_G.ADDON = {
+				SaveData = function(_, key, value)
+					store[key] = value
+				end,
+				LoadData = function(_, key)
+					return store[key]
+				end,
+				ClearData = function(_, key)
+					store[key] = nil
+				end,
+			}
+		end)
+
+		it("defaults to shown (true) when nothing is saved", function()
+			assert.is_true(WindowState.LoadVisibility("widget"))
+		end)
+
+		it("honours an explicit default when nothing is saved", function()
+			assert.is_false(WindowState.LoadVisibility("widget", false))
+		end)
+
+		it("round-trips a saved visibility", function()
+			WindowState.SaveVisibility("widget", false)
+			assert.is_false(WindowState.LoadVisibility("widget"))
+
+			WindowState.SaveVisibility("widget", true)
+			assert.is_true(WindowState.LoadVisibility("widget"))
+		end)
+	end)
+
+	describe("TrackPosition", function()
+		it("anchors at the loaded position and persists on drag stop", function()
+			local path = tmpPath()
+			WindowState.SavePosition(path, 60, 70)
+
+			local handlers = {}
+			local anchored
+			local fakeWindow = {
+				AddAnchor = function(_, point, relativeTo, x, y)
+					anchored = { point, relativeTo, x, y }
+				end,
+				SetHandler = function(_, name, fn)
+					handlers[name] = fn
+				end,
+				StartMoving = function() end,
+				StopMovingOrSizing = function() end,
+				GetOffset = function()
+					return 111, 222
+				end,
+			}
+
+			WindowState.TrackPosition(fakeWindow, path, 0, 0)
+
+			assert.same({ "TOPLEFT", "UIParent", 60, 70 }, anchored)
+			assert.is_function(handlers.OnDragStart)
+			assert.is_function(handlers.OnDragStop)
+
+			-- Simulate the user dragging the window to a new spot.
+			handlers.OnDragStop(fakeWindow)
+
+			local x, y = WindowState.LoadPosition(path)
+			assert.equals(111, x)
+			assert.equals(222, y)
+			os.remove(path)
+		end)
+	end)
+end)


### PR DESCRIPTION
## What

Adds a unit-test pipeline. The repo had lint CI (luacheck) but nothing that ran tests.

- `.github/workflows/lua-test.yml` - a **Lua Tests** workflow running [busted](https://lunarmodules.github.io/busted/) on Lua 5.1 for every push and pull request.
- `.busted` - test runner config (specs in `spec/`, `*_spec.lua`).
- `spec/windowstate_spec.lua` - the first spec suite.
- `globals/windowstate.lua` - the module under test (see below).
- README gains a **Tests** section.

## Why this module first

Almost every addon talks directly to the live ArcheRage UI API (`UIParent`, `X2*`, widgets), which can't run headless, so it isn't unit-testable as written. `globals/windowstate.lua` is the first module with a game-independent interface: file IO plus mockable `ADDON` calls. It is the natural seed for a test suite, and keeping future logic free of UI globals is what lets it be covered here.

The module is **bundled into this PR** so the pipeline has a real subject and CI is green standalone. It is also introduced - together with its `gearswap`/`timeuntil` migrations - in #24. Whichever merges first wins; the other rebases (the `windowstate.lua` content is identical).

## Coverage

- `LoadPosition` / `SavePosition` round-trips, including negative offsets (regression guard: the old `(%d+)` pattern reset them to 0,0) and fractional flooring.
- `LoadVisibility` / `SaveVisibility` against a mock `ADDON` data store.
- `TrackPosition` anchoring at the loaded position and persisting on drag stop, against a mock window.

## Testing

- `luacheck` clean on the new module and spec.
- `busted` syntax/logic authored for Lua 5.1; **not run locally** (no Lua toolchain on the dev machine). The Lua Tests workflow in this PR is the first execution - see the PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)